### PR TITLE
Fix for MSVC

### DIFF
--- a/library/tools.c
+++ b/library/tools.c
@@ -358,7 +358,7 @@ char* cpUint32ToStr(uint32_t* uipBuf, aint uiLen, char* cpStr){
  * NOTE: Returns a structure, not a pointer to a structure.
  */
 u32_phrase sStrToPhrase32(const char* cpStr, uint32_t* uipBuf){
-    u32_phrase sPhrase = {};
+    u32_phrase sPhrase = {0, 0};
     aint uiStrLen = strlen(cpStr);
     aint ui = 0;
     for(; ui < uiStrLen; ui++){

--- a/utilities/format.c
+++ b/utilities/format.c
@@ -69,6 +69,10 @@ static const void* s_vpMagicNumber = (void*)"format";
 #include "../library/lib.h"
 #include "./objects.h"
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 /** \struct fmt_tag
  * \brief The context for the format object.
  *

--- a/utilities/utilities.c
+++ b/utilities/utilities.c
@@ -31,12 +31,22 @@
  * \brief Utility functions code.
  */
 
-#include <unistd.h>
+#ifdef _MSC_VER
+    #include <direct.h>
+    #define getcwd _getcwd
+#else
+    #include <unistd.h>
+#endif
+
 #include <limits.h>
 
 #include "./utilities.h"
 
-static const size_t s_uiBufSize = (PATH_MAX + 128);
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define s_uiBufSize ((size_t) (PATH_MAX + 128))
 static char s_cPeriod = 46;
 static char* s_cpBinaryVal[16] = {
         "00 00", "00 01", "00 10", "00 11",


### PR DESCRIPTION
I have found that runtime library is unable to compile under MSVC compiler. List of fix is shown below:
- in `tools.c` I have changed way to init empty structure, to be compatible with C standard. In C17 there is no possiblity to put empty initialization list according to [this](https://en.cppreference.com/w/c/language/struct_initialization) (it looks that C23 will add this, but MSVC is not compatible with this standard).

- in `format.c` I put definition of `PATH_MAX` which is only declared in `linux/limits.h` on Linux. I set value to `4096`.

- in `utilities.c` I also put definition of `PATH_MAX` (probably it could be better place for it).
- in `utilities.c` was a problem with unistd.h which not exists on systems without posix. Currently I'm checking macro `_MSC_VER`, and if it exists I'm including `<direct.h>`. It contains `_getcwd` function which I rename to `getcwd`.
- in `utitilities.c` there was also problem with initialization of array in `vUtilCurrentWorkingDirectory` function. C language not allows to put consts as element number (it will be added in C23). Currently I change `s_uiBufSize` to macro.

I hope this changes will help to make runtime library more portable.